### PR TITLE
Change the scheduled delay config to send all spans before the tests are finished in the 08_opentelemetry exercise

### DIFF
--- a/exercises/01_structured_logging/08_opentelemetry/Cargo.toml
+++ b/exercises/01_structured_logging/08_opentelemetry/Cargo.toml
@@ -9,7 +9,7 @@ hyper = { workspace = true, features = ["full"] }
 opentelemetry = { workspace = true }
 opentelemetry-otlp = { workspace = true, features = ["tls-roots"] }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
-tonic = { workspace = true }
+tonic = { workspace = true, features = ["tls-roots"] }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true, default-features = true, features = ["fmt", "json"] }

--- a/exercises/01_structured_logging/08_opentelemetry/tests/failure.rs
+++ b/exercises/01_structured_logging/08_opentelemetry/tests/failure.rs
@@ -1,5 +1,6 @@
 use opentelemetry::global::shutdown_tracer_provider;
 use opentelemetry_training::init_test_subscriber;
+use std::time::Duration;
 
 #[tokio::test]
 async fn failure() {
@@ -7,6 +8,9 @@ async fn failure() {
     let order_numbers = vec![3, 4, 5];
 
     opentelemetry_training::get_total(&order_numbers).unwrap_err();
+
+    // Wait for the batch exporter to export all spans before the test is finished
+    tokio::time::sleep(Duration::from_secs(2)).await;
 
     // Ensure all spans are exported
     tokio::task::spawn_blocking(|| shutdown_tracer_provider())

--- a/exercises/01_structured_logging/08_opentelemetry/tests/success.rs
+++ b/exercises/01_structured_logging/08_opentelemetry/tests/success.rs
@@ -1,5 +1,6 @@
 use opentelemetry::global::shutdown_tracer_provider;
 use opentelemetry_training::init_test_subscriber;
+use std::time::Duration;
 
 #[tokio::test]
 async fn success() {
@@ -10,6 +11,9 @@ async fn success() {
 
     // Check that the total is correct.
     assert_eq!(total, 3117);
+
+    // Wait for the batch exporter to export all spans before the test is finished
+    tokio::time::sleep(Duration::from_secs(2)).await;
 
     // Ensure all spans are exported
     tokio::task::spawn_blocking(|| shutdown_tracer_provider())


### PR DESCRIPTION
Hi!

The `08_opentelemetry` exercise has [an issue](https://github.com/mainmatter/rust-telemetry-workshop/issues/13) with sending spans to HoneyComb. When I looked into the issue, the tests seemed to finish before the batch exporter exported all spans to HoneyComb since the batch exporter had a 5-second scheduled delay by default.

This problem may be solved using `install_simple` instead of `install_batch.` However, `install_simple` isn't usable due to [this issue](https://github.com/open-telemetry/opentelemetry-rust/issues/2188), so I think it would be better to change the scheduled delay to improve the workshop experience.

